### PR TITLE
Refactor data model

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: elixir
 
 elixir:
-  - 1.2.5
+  - 1.3.0-rc.1
 
 otp_release:
-  - 18.0
+  - 18.3
 
 env:
   - MIX_ENV=test

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ otp_release:
 env:
   - MIX_ENV=test
 
+before_script:
+  - mix local.rebar --force
+
 script: mix coveralls.travis
 
 after_script:

--- a/README.md
+++ b/README.md
@@ -12,13 +12,19 @@ Prometheus for scraping.
 **Note**: this package is very much work in progress. Nothing is stable yet. Do
 not use this in production.
 
+**Note**: Promex requires Elixir 1.3 to work.
+
 ## To do before 1.0 release
 
 Promex adheres to [Prometheus' client library guide](https://prometheus.io/docs/instrumenting/writing_clientlibs/)
 as much as possible. These things are still required to make that happen, in no
 particular order:
 
-- [ ] Allow having metrics with the same name but different labels. E.g.
+- [ ] Implement standard/runtime collectors, as [documented here](https://docs.google.com/document/d/1Q0MXWdwp1mdXCzNRak6bW5LLVylVRXhdi7_21Sg15xQ/edit).
+- [ ] Add support for pushing metrics to a PushGateway, e.g. for short-running
+    batch processes.
+- [ ] Implement `summary` and/or `histogram` metric type
+- [x] Allow having metrics with the same name but different labels. E.g.
     `requests{status="200"}` and `requests{status="404"}` should be exported
     like:
 
@@ -28,10 +34,6 @@ particular order:
     requests{status="200"} <value> <timestamp>
     requests{status="404"} <value> <timestamp>
     ```
-- [ ] Implement standard/runtime collectors, as [documented here](https://docs.google.com/document/d/1Q0MXWdwp1mdXCzNRak6bW5LLVylVRXhdi7_21Sg15xQ/edit).
-- [ ] Add support for pushing metrics to a PushGateway, e.g. for short-running
-    batch processes.
-- [ ] Implement `summary` and/or `histogram` metric type
 - [x] Make it possible to add labels to a metric, and expose them in the
     exporter
 - [x] Refactor code so metrics can be registered to one or more registries which
@@ -86,13 +88,13 @@ To register a metric in a non-default registry, use
 To collect all metrics from the default registry, use `Promex.Registry.collect/0`:
 
     iex> Promex.Registry.collect
-    %{"foo" => 0, ...}
+    [%Promex.Counter{...}, ...]
 
 To collect all metrics from a non-default registry, use
 `Promex.Registry.collect/1`:
 
     iex> Promex.Registry.collect :web
-    %{"foo" => 0, ...}
+    [%Promex.Counter{...}, ...]
 
 ## Types
 
@@ -160,3 +162,27 @@ Promex can be configured in `config.exs`. These are the default settings:
     config :promex,
       port: 9000
       endpoint: "/metrics"
+
+## Data Model
+
+A single metric can have multiple pairs of labels/value assigned to it. For
+instance, a metric named `http_requests_total` can have the labels/value pairs
+`{status=200, api=true}` with counter value 100 and `{status=404, api=true}` with
+counter value 300. In Prometheus' text format, this renders as:
+
+    # TYPE http_requests_total counter
+    http_requests_total{status="200", api="true"} 100
+    http_requests_total{status="404", api="true"} 300
+
+Promex supports this by storing labels/value pairs in a nested `values` map in
+the metric. E.g.:
+
+    %Promex.Counter{
+      doc: nil,
+      name: "foo",
+      values: %{
+        %{api: true, status: 200} => 3,
+        %{api: true, status: 404} => 1}
+      }
+
+[Read more about Prometheus' text format here](https://prometheus.io/docs/instrumenting/exposition_formats/#text-format-details)

--- a/lib/promex/counter.ex
+++ b/lib/promex/counter.ex
@@ -19,12 +19,24 @@ defmodule Promex.Counter do
   Increment the counter identified by `name` by 1, or initialize it with a
   value of 1.
   """
-  def increment(name), do: increment(name, by: 1)
+  def increment(name), do: increment(name, by: 1, labels: %{})
+
+  @doc """
+  Increment the counter identified by `name` by `by`, or initialize it with a
+  value of `by`.
+  """
+  def increment(name, [by: by]), do: increment(name, by: by, labels: %{})
+
+  @doc """
+  Increment the counter identified by `name` by 1, or initialize it with a
+  value of 1, while setting `labels` as labels.
+  """
+  def increment(name, [labels: labels]), do: increment(name, by: 1, labels: labels)
 
   @doc """
   Increment the counter identified by `name` by a specific value.
   """
-  def increment(registry \\ :default, name, [by: value]) do
-    GenServer.call(Promex.Registry.name(registry), {:counter, :increment, name, by: value})
+  def increment(registry \\ :default, name, [by: value, labels: labels]) do
+    GenServer.call(Promex.Registry.name(registry), {:counter, :increment, name, by: value, labels: labels})
   end
 end

--- a/lib/promex/exporter.ex
+++ b/lib/promex/exporter.ex
@@ -50,7 +50,9 @@ defmodule Promex.Exporter do
   defp help(%{name: name, doc: doc}), do: "HELP #{name} #{doc}"
 
   defp value(metric) do
-    "#{metric.name}" <> labels(metric.labels) <> " " <> "#{inspect metric.values}\n"
+    for {labels, value} <- metric.values do
+      "#{metric.name}" <> labels(labels) <> " " <> "#{inspect value}\n"
+    end
   end
 
   # Transforms a map of labels to the curly enclosed, comma separated

--- a/lib/promex/exporter.ex
+++ b/lib/promex/exporter.ex
@@ -37,7 +37,7 @@ defmodule Promex.Exporter do
   defp parse([metric | list], result),  do: parse(list, parsed(metric) <> result)
   defp parse([], result),               do: result
 
-  defp parsed(metric = %{name: _name, value: _value, doc: _doc}) do
+  defp parsed(metric = %{name: _name, values: _values, doc: _doc}) do
     [type(metric),
      help(metric),
      value(metric)]
@@ -49,8 +49,8 @@ defmodule Promex.Exporter do
   defp help(%{doc: nil}),             do: ""
   defp help(%{name: name, doc: doc}), do: "HELP #{name} #{doc}"
 
-  defp value(%{name: name, value: value, labels: labels}) do
-    "#{name}" <> labels(labels) <> " " <> "#{inspect value}\n"
+  defp value(metric) do
+    "#{metric.name}" <> labels(metric.labels) <> " " <> "#{inspect metric.values}\n"
   end
 
   # Transforms a map of labels to the curly enclosed, comma separated

--- a/lib/promex/gauge.ex
+++ b/lib/promex/gauge.ex
@@ -12,18 +12,21 @@ defmodule Promex.Gauge do
   def set(name), do: set(name, [to: 1])
 
   @doc """
-  Set the gauge identified by `name` to the value `value`.
+  Set the gauge identified by `name` to the value `value` without labels.
   """
-  def set(registry \\ :default, name, [to: value]) do
-    GenServer.call(Promex.Registry.name(registry), {:gauge, :set, name, value})
+  def set(name, [to: value]), do: set(name, [to: value, labels: %{}])
+
+  @doc """
+  Set the gauge identified by `name` to the value `value` with labels `labels`.
+  """
+  def set(registry \\ :default, name, [to: value, labels: labels]) do
+    GenServer.call(Promex.Registry.name(registry), {:gauge, :set, name, [to: value, labels: labels]})
   end
 
   @doc """
-  Set the gauge to the current time (in seconds since Unix epoch).
+  Set the gauge to the current time (in seconds since Unix epoch) with no labels.
   """
-  def set_to_current_time(registry \\ :default, name) do
-    GenServer.call(Promex.Registry.name(registry), {:gauge, :set, name, unix_time})
-  end
+  def set_to_current_time(name), do: set(name, to: unix_time)
 
   @doc """
   Alias for `increment/1`
@@ -42,10 +45,15 @@ defmodule Promex.Gauge do
   def increment(name), do: increment(name, by: 1)
 
   @doc """
-  Increment the gauge identified by `name` by a specific value.
+  Increment the gauge identified by `name` by a specific value with no labels.
   """
-  def increment(registry \\ :default, name, [by: value]) do
-    GenServer.call(Promex.Registry.name(registry), {:gauge, :increment, name, by: value})
+  def increment(name, [by: value]), do: increment(name, [by: value, labels: %{}])
+
+  @doc """
+  Increment the gauge identified by `name` by a specific value with labels `labels`.
+  """
+  def increment(registry \\ :default, name, [by: value, labels: labels]) do
+    GenServer.call(Promex.Registry.name(registry), {:gauge, :increment, name, by: value, labels: labels})
   end
 
   @doc """
@@ -60,15 +68,21 @@ defmodule Promex.Gauge do
 
   @doc """
   Decrement the gauge identified by `name` by 1, or initialize it with a
-  value of -1.
+  value of -1 with no labels.
   """
-  def decrement(name), do: decrement(name, by: 1)
+  def decrement(name), do: decrement(name, by: 1, labels: %{})
+
+  @doc """
+  Decrement the gauge identified by `name` by `value`, or initialize it with a
+  value of -`value` with no labels.
+  """
+  def decrement(name, [by: value]), do: decrement(name, by: value, labels: %{})
 
   @doc """
   Decrement the gauge identified by `name` by a specific value.
   """
-  def decrement(registry \\ :default, name, [by: value]) do
-    GenServer.call(Promex.Registry.name(registry), {:gauge, :decrement, name, by: value})
+  def decrement(registry \\ :default, name, [by: value, labels: labels]) do
+    GenServer.call(Promex.Registry.name(registry), {:gauge, :decrement, name, by: value, labels: labels})
   end
 
   defp unix_time, do: Timex.Time.now |> Timex.to_unix

--- a/lib/promex/metric.ex
+++ b/lib/promex/metric.ex
@@ -1,11 +1,14 @@
 defmodule Promex.Metric do
   defmacro __using__(_opts) do
     quote do
-      defstruct name: nil, doc: nil, value: 0, labels: %{}
+      defstruct name: nil, doc: nil, values: %{}
     end
   end
 
   def type(metric) when is_map(metric), do: type(metric.__struct__)
   def type(Promex.Counter), do: "counter"
   def type(Promex.Gauge), do: "gauge"
+  def type(label) do
+    raise ArgumentError, message: "#{label} is not a valid metric type"
+  end
 end

--- a/lib/promex/registry.ex
+++ b/lib/promex/registry.ex
@@ -49,7 +49,6 @@ defmodule Promex.Registry do
       {:reply, Map.fetch(state, name), state}
     else
       false -> {:reply, {:error, "metric '#{name}' is not registered"}, state}
-          _ -> {:reply, {:error, "an error occurred"}, state}
     end
   end
 
@@ -71,7 +70,6 @@ defmodule Promex.Registry do
       {:reply, Map.fetch(state, name), state}
     else
       false -> {:reply, {:error, "metric '#{name}' is not registered"}, state}
-          _ -> {:reply, {:error, "an error occurred"}, state}
     end
   end
 
@@ -81,7 +79,6 @@ defmodule Promex.Registry do
       {:reply, Map.fetch(state, name), state}
     else
       false -> {:reply, {:error, "metric '#{name}' is not registered"}, state}
-          _ -> {:reply, {:error, "an error occurred"}, state}
     end
   end
 
@@ -95,7 +92,6 @@ defmodule Promex.Registry do
       {:reply, Map.fetch(state, name), state}
     else
       false -> {:reply, {:error, "metric '#{name}' is not registered"}, state}
-          _ -> {:reply, {:error, "an error occurred"}, state}
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -33,7 +33,6 @@ defmodule Promex.Mixfile do
       {:inch_ex, "~> 0.5.0", only: :docs},
       {:earmark, "~> 0.1.0", only: :dev},
       {:ex_doc, "~> 0.11.0", only: :dev},
-      {:mix_test_watch, "~> 0.2", only: :dev},
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -28,8 +28,6 @@ defmodule Promex.Mixfile do
       {:timex, "~> 2.1.0"},
 
       # Testing/development/docs dependencies
-      {:credo, "~> 0.3.10", only: [:dev, :test]},
-      {:dialyxir, "~> 0.3.3", only: [:dev, :test]},
       {:mock, "~> 0.1.1", only: :test},
       {:excoveralls, "~> 0.5", only: :test},
       {:inch_ex, "~> 0.5.0", only: :docs},

--- a/test/promex/counter_test.exs
+++ b/test/promex/counter_test.exs
@@ -7,24 +7,42 @@ defmodule Promex.CounterTest do
 
   test "increment" do
     {:ok, value} = Promex.Counter.increment("foo")
-    assert value == %Promex.Counter{name: "foo", value: 1}
+    assert value == %Promex.Counter{name: "foo", values: %{%{} => 1}}
 
     {:ok, value} = Promex.Counter.increment("foo", by: 2)
-    assert value == %Promex.Counter{name: "foo", value: 3}
+    assert value == %Promex.Counter{name: "foo", values: %{%{} => 3}}
 
-    {:error, msg} = Promex.Counter.increment("foo", by: -1)
+    {:ok, value} = Promex.Counter.increment("foo", labels: %{status: 200})
+    assert value == %Promex.Counter{name: "foo", values: %{%{} => 3, %{status: 200} => 1}}
+
+    {:ok, value} = Promex.Counter.increment("foo", by: 2, labels: %{status: 200})
+    assert value == %Promex.Counter{name: "foo", values: %{%{} => 3, %{status: 200} => 3}}
+
+    {:error, msg} = Promex.Counter.increment("foo", by: -1, labels: %{})
     assert msg == "increment must be a non-negative number"
 
-    {:error, msg} = Promex.Counter.increment("foo", by: "A")
+    {:error, msg} = Promex.Counter.increment("foo", by: "A", labels: %{})
     assert msg == "increment must be a number"
   end
 
   test "inc" do
     {:ok, value} = Promex.Counter.inc("foo")
-    assert value == %Promex.Counter{name: "foo", value: 1}
+    assert value == %Promex.Counter{name: "foo", values: %{%{} => 1}}
 
     {:ok, value} = Promex.Counter.inc("foo", by: 2)
-    assert value == %Promex.Counter{name: "foo", value: 3}
+    assert value == %Promex.Counter{name: "foo", values: %{%{} => 3}}
+
+    {:ok, value} = Promex.Counter.inc("foo", labels: %{status: 200})
+    assert value == %Promex.Counter{name: "foo", values: %{%{} => 3, %{status: 200} => 1}}
+
+    {:ok, value} = Promex.Counter.inc("foo", by: 2, labels: %{status: 200})
+    assert value == %Promex.Counter{name: "foo", values: %{%{} => 3, %{status: 200} => 3}}
+
+    {:error, msg} = Promex.Counter.inc("foo", by: -1, labels: %{})
+    assert msg == "increment must be a non-negative number"
+
+    {:error, msg} = Promex.Counter.inc("foo", by: "A", labels: %{})
+    assert msg == "increment must be a number"
   end
 
 end

--- a/test/promex/exporter_test.exs
+++ b/test/promex/exporter_test.exs
@@ -4,8 +4,12 @@ defmodule Promex.ExporterTest do
   import Mock
 
   @collect [
-    %Promex.Counter{name: "foo", value: 3, doc: "this is a counter", labels: %{foo: "bar", baz: "bax"}},
-    %Promex.Gauge{name: "bar", value: 5, doc: "this is a gauge"},
+    %Promex.Counter{name: "foo", doc: "this is a counter", values: %{
+        %{} => 10,
+        %{foo: "bar"} => 15
+      }
+    },
+    %Promex.Gauge{name: "bar", doc: "this is a gauge"},
   ]
 
   test "returns parsed metrics" do

--- a/test/promex/exporter_test.exs
+++ b/test/promex/exporter_test.exs
@@ -4,12 +4,21 @@ defmodule Promex.ExporterTest do
   import Mock
 
   @collect [
-    %Promex.Counter{name: "foo", doc: "this is a counter", values: %{
+    %Promex.Counter{
+      name: "foo",
+      doc: "this is a counter",
+      values: %{
         %{} => 10,
         %{foo: "bar"} => 15
       }
     },
-    %Promex.Gauge{name: "bar", doc: "this is a gauge"},
+    %Promex.Gauge{
+      name: "bar",
+      doc: "this is a gauge",
+      values: %{
+        %{} => 5
+      }
+    },
   ]
 
   test "returns parsed metrics" do
@@ -25,7 +34,8 @@ defmodule Promex.ExporterTest do
       bar 5
       TYPE foo counter
       HELP foo this is a counter
-      foo{baz="bax",foo="bar"} 3
+      foo 10
+      foo{foo="bar"} 15
       """
     end
   end

--- a/test/promex/gauge_test.exs
+++ b/test/promex/gauge_test.exs
@@ -10,10 +10,10 @@ defmodule Promex.GaugeTest do
 
   test "set" do
     {:ok, value} = Promex.Gauge.set("foo")
-    assert value == %Promex.Gauge{name: "foo", value: 1}
+    assert value == %Promex.Gauge{name: "foo", values: %{%{} => 1}}
 
     {:ok, value} = Promex.Gauge.set("foo", to: 5)
-    assert value == %Promex.Gauge{name: "foo", value: 5}
+    assert value == %Promex.Gauge{name: "foo", values: %{%{} => 5}}
 
     {:error, msg} = Promex.Gauge.set("foo", to: "A")
     assert msg == "value must be a number"
@@ -22,16 +22,16 @@ defmodule Promex.GaugeTest do
   test "set_to_current_time" do
     with_mock Timex, [to_unix: fn(_time) -> 62167219200 end] do
       {:ok, value} = Promex.Gauge.set_to_current_time("foo")
-      assert value == %Promex.Gauge{name: "foo", value: 62167219200}
+      assert value == %Promex.Gauge{name: "foo", values: %{%{} => 62167219200}}
     end
   end
 
   test "increment" do
     {:ok, value} = Promex.Gauge.increment("foo")
-    assert value == %Promex.Gauge{name: "foo", value: 1}
+    assert value == %Promex.Gauge{name: "foo", values: %{%{} =>1}}
 
     {:ok, value} = Promex.Gauge.increment("foo", by: 5)
-    assert value == %Promex.Gauge{name: "foo", value: 6}
+    assert value == %Promex.Gauge{name: "foo", values: %{%{} => 6}}
 
     {:error, msg} = Promex.Gauge.increment("foo", by: "A")
     assert msg == "increment must be a number"
@@ -39,10 +39,10 @@ defmodule Promex.GaugeTest do
 
   test "inc" do
     {:ok, value} = Promex.Gauge.inc("foo")
-    assert value == %Promex.Gauge{name: "foo", value: 1}
+    assert value == %Promex.Gauge{name: "foo", values: %{%{} => 1}}
 
     {:ok, value} = Promex.Gauge.inc("foo", by: 5)
-    assert value == %Promex.Gauge{name: "foo", value: 6}
+    assert value == %Promex.Gauge{name: "foo", values: %{%{} => 6}}
 
     {:error, msg} = Promex.Gauge.increment("foo", by: "A")
     assert msg == "increment must be a number"
@@ -50,10 +50,10 @@ defmodule Promex.GaugeTest do
 
   test "decrement" do
     {:ok, value} = Promex.Gauge.decrement("foo")
-    assert value == %Promex.Gauge{name: "foo", value: -1}
+    assert value == %Promex.Gauge{name: "foo", values: %{%{} => -1}}
 
     {:ok, value} = Promex.Gauge.decrement("foo", by: 5)
-    assert value == %Promex.Gauge{name: "foo", value: -6}
+    assert value == %Promex.Gauge{name: "foo", values: %{%{} => -6}}
 
     {:error, msg} = Promex.Gauge.decrement("foo", by: "A")
     assert msg == "decrement must be a number"
@@ -61,10 +61,10 @@ defmodule Promex.GaugeTest do
 
   test "dec" do
     {:ok, value} = Promex.Gauge.dec("foo")
-    assert value == %Promex.Gauge{name: "foo", value: -1}
+    assert value == %Promex.Gauge{name: "foo", values: %{%{} => -1}}
 
     {:ok, value} = Promex.Gauge.dec("foo", by: 5)
-    assert value == %Promex.Gauge{name: "foo", value: -6}
+    assert value == %Promex.Gauge{name: "foo", values: %{%{} => -6}}
 
     {:error, msg} = Promex.Gauge.dec("foo", by: "A")
     assert msg == "decrement must be a number"

--- a/test/promex/metric_test.exs
+++ b/test/promex/metric_test.exs
@@ -1,0 +1,12 @@
+defmodule Promex.MetricTest do
+  use ExUnit.Case
+
+  test "determine type" do
+    assert Promex.Metric.type(%Promex.Counter{}) == "counter"
+    assert Promex.Metric.type(%Promex.Gauge{}) == "gauge"
+
+    assert_raise ArgumentError, "foo is not a valid metric type", fn ->
+      Promex.Metric.type("foo")
+    end
+  end
+end

--- a/test/promex/registry_test.exs
+++ b/test/promex/registry_test.exs
@@ -17,8 +17,26 @@ defmodule Promex.RegistryTest do
     assert state == %{"foo" => metric}
   end
 
-  test "can not increment a metric that is not registered" do
+  test "can not increment a counter that is not registered" do
     {:reply, reply, state} = Promex.Registry.handle_call({:counter, :increment, "foo", [by: 10, labels: %{}]}, nil, %{})
+    assert reply == {:error, "metric 'foo' is not registered"}
+    assert state == %{}
+  end
+
+  test "can not set a gauge that is not registered" do
+    {:reply, reply, state} = Promex.Registry.handle_call({:gauge, :set, "foo", [to: 10, labels: %{}]}, nil, %{})
+    assert reply == {:error, "metric 'foo' is not registered"}
+    assert state == %{}
+  end
+
+  test "can not increment a gauge that is not registered" do
+    {:reply, reply, state} = Promex.Registry.handle_call({:gauge, :increment, "foo", [by: 10, labels: %{}]}, nil, %{})
+    assert reply == {:error, "metric 'foo' is not registered"}
+    assert state == %{}
+  end
+
+  test "can not decrement a gauge that is not registered" do
+    {:reply, reply, state} = Promex.Registry.handle_call({:gauge, :decrement, "foo", [by: 10, labels: %{}]}, nil, %{})
     assert reply == {:error, "metric 'foo' is not registered"}
     assert state == %{}
   end

--- a/test/promex/registry_test.exs
+++ b/test/promex/registry_test.exs
@@ -2,7 +2,7 @@ defmodule Promex.RegistryTest do
   use ExUnit.Case
 
   setup do
-    metric = %Promex.Counter{name: "foo", doc: "this is the help text", value: 0}
+    metric = %Promex.Counter{name: "foo", doc: "this is the help text", values: %{%{} => 0}}
     {:ok, metric: metric}
   end
 
@@ -17,28 +17,22 @@ defmodule Promex.RegistryTest do
     assert state == %{"foo" => metric}
   end
 
-  test "creates a new counter with initial value 1" do
-    {:reply, reply, state} = Promex.Registry.handle_call({:counter, :increment, "foo", [by: 1]}, nil, %{})
-    assert reply == {:ok, %Promex.Counter{name: "foo", value: 1}}
-    assert state == %{"foo" => %Promex.Counter{name: "foo", value: 1}}
-  end
-
-  test "creates a new counter with initial value 10" do
-    {:reply, reply, state} = Promex.Registry.handle_call({:counter, :increment, "foo", [by: 10]}, nil, %{})
-    assert reply == {:ok, %Promex.Counter{name: "foo", value: 10}}
-    assert state == %{"foo" => %Promex.Counter{name: "foo", value: 10}}
+  test "can not increment a metric that is not registered" do
+    {:reply, reply, state} = Promex.Registry.handle_call({:counter, :increment, "foo", [by: 10, labels: %{}]}, nil, %{})
+    assert reply == {:error, "metric 'foo' is not registered"}
+    assert state == %{}
   end
 
   test "increments an existing counter by 1", %{metric: metric} do
-    {:reply, reply, state} = Promex.Registry.handle_call({:counter, :increment, "foo", [by: 1]}, nil, %{"foo" => metric})
-    assert reply == {:ok, %{metric | value: 1}}
-    assert state == %{"foo" => %{metric | value: 1}}
+    {:reply, reply, state} = Promex.Registry.handle_call({:counter, :increment, "foo", [by: 1, labels: %{}]}, nil, %{"foo" => metric})
+    assert reply == {:ok, %{metric | values: %{%{} => 1}}}
+    assert state == %{"foo" => %{metric | values: %{%{} => 1}}}
   end
 
   test "increments an existing counter by 10", %{metric: metric} do
-    {:reply, reply, state} = Promex.Registry.handle_call({:counter, :increment, "foo", [by: 10]}, nil, %{"foo" => metric})
-    assert reply == {:ok, %{metric | value: 10}}
-    assert state == %{"foo" => %{metric | value: 10}}
+    {:reply, reply, state} = Promex.Registry.handle_call({:counter, :increment, "foo", [by: 10, labels: %{}]}, nil, %{"foo" => metric})
+    assert reply == {:ok, %{metric | values: %{%{} => 10}}}
+    assert state == %{"foo" => %{metric | values: %{%{} => 10}}}
   end
 
 end


### PR DESCRIPTION
This refactors the metrics storage data model to support multiple labels/value pairs per metric. See README and [this page](https://prometheus.io/docs/instrumenting/exposition_formats/#text-format-details) for more info.
